### PR TITLE
Merge params

### DIFF
--- a/lib/rufus/verbs/endpoint.rb
+++ b/lib/rufus/verbs/endpoint.rb
@@ -270,11 +270,19 @@ module Verbs
       opts[:host] = r[1] || @opts[:host]
       opts[:port] = r[2] || @opts[:port]
       opts[:path] = r[3] || @opts[:path]
-
+      
+      # Merge EndPoint params and Request params
+      
+      def_params = @opts[:query] || @opts[:params]
+      req_params = opts[:query] || opts[:params]
+      
+      mer_params = def_params.merge req_params if def_params && req_params
+      
       opts[:query] =
         r[4] ||
-        opts[:params] || opts[:query] ||
-        @opts[:query] || @opts[:params] ||
+        mer_params ||
+        req_params ||
+        def_params ||
         {}
 
       opts.delete :path if opts[:path] == ''

--- a/test/merge_test.rb
+++ b/test/merge_test.rb
@@ -1,0 +1,23 @@
+
+require File.dirname(__FILE__) + '/base.rb'
+
+
+class MergeTest < Test::Unit::TestCase
+
+  include Rufus::Verbs
+
+
+  def test_0
+    
+    ep = EndPoint.new(
+      :dry_run => true,
+      :uri => 'http://host/path',
+      :params => { 'token' => 'apiaccess'})
+
+    req = ep.get(
+      :params => { 'extra' => 'param'})
+
+    assert_equal "/path?token=apiaccess&extra=param", req.path
+    
+  end
+end


### PR DESCRIPTION
Currently it is not possible to set both a default EndPoint parameter/query and use extra parameters specific for the request. I have made some small changes that merge EndPoint params with request params. This is especially useful when using a public API that uses a ?token= kind of authentication.

I added a test case (merge_test.rb) and all existing tests seem to be running as before. The URL escaping test case seems to be failing but that doesn't have anything to do with my changes since it fails on the master branche as well.
