### PR TITLE
Automatic content parsing

### DIFF
--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1,0 +1,47 @@
+
+require File.dirname(__FILE__) + '/base.rb'
+
+class PlainText
+  
+  def self.parse text
+    self.new text
+  end
+  
+  def initialize text
+    @text = text
+  end
+  
+end
+
+class ParseTest < Test::Unit::TestCase
+  include TestBaseMixin
+  include Rufus::Verbs
+  
+  # def test_0
+  #   ep = EndPoint.new(
+  #     :host => "localhost", 
+  #     :port => 7777,
+  #     :headers => {'Accept' => 'text/plain'})
+  #     
+  #   ep.parsers['text/plain'] = PlainText
+  #   
+  #   resp = ep.get(:resource => "items")
+  #   
+  #   assert_equal 'text/plain', resp.header['content-type']
+  #   assert_equal PlainText, resp.body.class
+  #       
+  # end
+  
+  def test_1
+    require 'nokogiri'
+    
+    ep = EndPoint.new(:host => 'rufus.rubyforge.org')
+    ep.parsers['text/html'] = Nokogiri::HTML::Document
+    
+    res = ep.get
+    
+    assert_equal Nokogiri::HTML::Document, res.body.class
+    
+  end  
+  
+end


### PR DESCRIPTION
It is now possible to configure parsers for different content-types (for each EndPoint) which will be used to parse the response body automatically. I tried to set up a isolated test case but had a hard time mocking a response that includes a 'content-type' header. So I ended up creating this temporary test case:

```
require 'nokogiri'

ep = EndPoint.new(:host => 'rufus.rubyforge.org')
ep.parsers['text/html'] = Nokogiri::HTML::Document

res = ep.get

assert_equal Nokogiri::HTML::Document, res.body.class
```

All other tests seem to be executing as before.
